### PR TITLE
Add support for `composer create-project`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ The starter lives at http://d8-starter-composer.io.dev.dev1.compact.amazee.io/ (
 
 How to setup a new project from d8-starter-composer: http://confluence.amazeelabs.com/display/KNOWLEDGE/Create+new+Drupal+8+Composer+project
 
+TL;DR
+```composer create-project --stability dev --no-interaction --keep-vcs --repository '{"type": "vcs","url": "https://github.com/AmazeeLabs/d8-starter-composer"}' AmazeeLabs/d8-starter-composer awesome-new-project_com```
+
 ## Recipes
 
 The most recent version of the following recipes can be found at https://github.com/AmazeeLabs/d8-starter-composer#readme

--- a/composer.json
+++ b/composer.json
@@ -52,15 +52,19 @@
     "autoload": {
         "classmap": [
             "scripts/composer/ScriptHandler.php",
-            "scripts/composer/AmazeeIO/ScriptHandler.php"
+            "scripts/composer/AmazeeIO/ScriptHandler.php",
+            "scripts/composer/AmazeeLabs/ScriptHandler.php"
         ]
     },
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
         "amazeeio-init": "AmazeeIO\\composer\\ScriptHandler::postInstall",
+        "amazeelabs-init": "AmazeeLabs\\composer\\ScriptHandler::postInstall",
+        "amazee-init": ["@amazeeio-init", "@amazeelabs-init"],
         "post-install-cmd": [
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
-            "AmazeeIO\\composer\\ScriptHandler::postInstall"
+            "AmazeeIO\\composer\\ScriptHandler::postInstall",
+            "AmazeeLabs\\composer\\ScriptHandler::postInstall"
         ],
         "post-update-cmd": [
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"

--- a/composer.json
+++ b/composer.json
@@ -51,13 +51,16 @@
     "prefer-stable": true,
     "autoload": {
         "classmap": [
-            "scripts/composer/ScriptHandler.php"
+            "scripts/composer/ScriptHandler.php",
+            "scripts/composer/AmazeeIO/ScriptHandler.php"
         ]
     },
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
+        "amazeeio-init": "AmazeeIO\\composer\\ScriptHandler::postInstall",
         "post-install-cmd": [
-            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
+            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
+            "AmazeeIO\\composer\\ScriptHandler::postInstall"
         ],
         "post-update-cmd": [
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"

--- a/scripts/composer/AmazeeIO/ScriptHandler.php
+++ b/scripts/composer/AmazeeIO/ScriptHandler.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @file
+ * Contains \AmazeeIO\composer\ScriptHandler.
+ */
+
+namespace AmazeeIO\composer;
+
+use Composer\Script\Event;
+
+class ScriptHandler {
+
+  public static function postInstall(Event $event) {
+    static::configureLocalEnvironment($event);
+  }
+
+  public static function configureLocalEnvironment(Event $event) {
+    $root = getcwd();
+    $handle = fopen ("php://stdin","r");
+
+    $event->getIO()->write('*****************************************
+***** amazee.io Local Docker Config *****
+*****************************************');
+
+    $event->getIO()->write('What is the sitegroup (e.g., awesome-new-project_com)?');
+    $site_name = trim(fgets($handle));
+
+    static::replaceInFile('d8-starter_composer_io', $site_name, $root . '/config/sync/system.site.yml');
+    static::replaceInFile('d8-starter_io_composer', $site_name, $root . '/.amazeeio.yml');
+
+    $event->getIO()->write('What is the hostname (e.g., new-project.com.docker.amazee.io)?');
+    $hostname = trim(fgets($handle));
+
+    static::replaceInFile('d8-starter-composer.io.docker.amazee.io', $hostname, $root . '/docker-compose.yml');
+  }
+
+  public static function replaceInFile($needle, $haystack, $file) {
+    $content = file_get_contents($file);
+    $replaced = str_replace($needle, $haystack, $content);
+    file_put_contents($file, $replaced);
+  }
+
+}

--- a/scripts/composer/AmazeeLabs/ScriptHandler.php
+++ b/scripts/composer/AmazeeLabs/ScriptHandler.php
@@ -23,10 +23,12 @@ class ScriptHandler {
 ***** d8-starter-composer Config *****
 *****************************************');
 
-    $event->getIO()->write('What is the vendor/project (e.g., AmazeeLabs/awesome-new-project_com)?');
-    $name = trim(fgets($handle));
+    $event->getIO()->write('What is the github project (e.g., AmazeeLabs/awesome-new-project_com)?');
+    $project = trim(fgets($handle));
 
-    static::replaceInFile('AmazeeLabs/d8-starter-composer', $name, $root . '/composer.json');
+    static::replaceInFile('AmazeeLabs/d8-starter-composer', $project, $root . '/composer.json');
+
+    exec('git remote set-url origin ' . escapeshellarg('git@github.com:' . $project . '.git'));
   }
 
   public static function replaceInFile($needle, $haystack, $file) {

--- a/scripts/composer/AmazeeLabs/ScriptHandler.php
+++ b/scripts/composer/AmazeeLabs/ScriptHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @file
+ * Contains \AmazeeLabs\composer\ScriptHandler.
+ */
+
+namespace AmazeeLabs\composer;
+
+use Composer\Script\Event;
+
+class ScriptHandler {
+
+  public static function postInstall(Event $event) {
+    static::configure($event);
+  }
+
+  public static function configure(Event $event) {
+    $root = getcwd();
+    $handle = fopen ("php://stdin","r");
+
+    $event->getIO()->write('*****************************************
+***** d8-starter-composer Config *****
+*****************************************');
+
+    $event->getIO()->write('What is the vendor/project (e.g., AmazeeLabs/awesome-new-project_com)?');
+    $name = trim(fgets($handle));
+
+    static::replaceInFile('AmazeeLabs/d8-starter-composer', $name, $root . '/composer.json');
+  }
+
+  public static function replaceInFile($needle, $haystack, $file) {
+    $content = file_get_contents($file);
+    $replaced = str_replace($needle, $haystack, $content);
+    file_put_contents($file, $replaced);
+  }
+
+}


### PR DESCRIPTION
This is an alternative for the bash script listed in confluence https://confluence.amazeelabs.com/display/KNOWLEDGE/Create+new+Drupal+8+Composer+project

It will allow anyone to create new d8-starter-composer projects easily without needing to install or remember the name of a custom back script.